### PR TITLE
Adds test backed by TestRPC that shows poor websocket reconnect behavior.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN npm install
 
 COPY . /ethrpc
 
-ENTRYPOINT [ "npm", "test" ]
+ENTRYPOINT [ "/ethrpc/node_modules/.bin/mocha" ]

--- a/package.json
+++ b/package.json
@@ -36,13 +36,15 @@
     "chalk": "^1.1.1",
     "coveralls": "^2.11.4",
     "del": "^1.2.1",
+    "ethereumjs-testrpc": "3.0.3",
     "geth": "^0.1.4",
     "gulp": "^3.9.0",
     "istanbul": "^0.3.18",
     "it-each": "^0.3.1",
     "jshint": "^2.8.0",
-    "mocha": "^2.2.5",
-    "uglify-js": "^2.4.24"
+    "mocha": "3.2.0",
+    "uglify-js": "^2.4.24",
+    "ws": "2.0.3"
   },
   "optionalDependencies": {
     "sync-request": "2.0.1",

--- a/test/testrpc.js
+++ b/test/testrpc.js
@@ -1,0 +1,88 @@
+"use strict";
+
+// workaround for https://github.com/ethereum/solc-js/issues/84
+const originalUncaughtExceptionListeners = process.listeners("uncaughtException")
+const TestRPC = require("ethereumjs-testrpc");
+process.removeAllListeners("uncaughtException");
+originalUncaughtExceptionListeners.forEach((listener) => process.addListener("uncaughtException", listener));
+
+const assert = require("chai").assert;
+const rpc = require("../");
+const WebSocket = require('ws');
+
+describe("connectivity", function () {
+  describe("websocket", function () {
+    let webSocketServer;
+    let ethereumNodeProvider;
+    before(function () {
+      rpc.disableHostedNodeFallback();
+      rpc.wsUrl = "ws://localhost:1337";
+      rpc.reset();
+      startWebSocketServer();
+    });
+
+    after(function () {
+      return new Promise((resolve, reject) => {
+        if (webSocketServer)
+          webSocketServer.close(function () { resolve() });
+        else
+          resolve();
+      }).then(function () {
+        rpc.enableHostedNodeFallback();
+        rpc.reset();
+      });
+    });
+
+    it("starts connected > uses connection > loses connection > reconnects > uses connection", (done) => {
+      rpc.version((version) => {
+        if (typeof version !== "string") return done(version);
+        assert.strictEqual(version, "5");
+        webSocketServer.close(function () {
+          startWebSocketServer();
+          rpc.version((version) => {
+            if (typeof version !== "string") return done(version);
+            assert.strictEqual(version, "5");
+            done();
+          });
+        });
+      });
+    });
+
+    it("starts connected > uses connection > loses connection > uses connection > reconnects > uses connection", function (done) {
+      rpc.version((version) => {
+        if (typeof version !== "string") return done(version);
+        assert.strictEqual(version, "5");
+        webSocketServer.close(function () {
+          rpc.version((error) => {
+            startWebSocketServer();
+            rpc.version((version) => {
+              if (typeof version !== "string") return done(version.message);
+              assert.strictEqual(version, "5");
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    function startWebSocketServer() {
+      ethereumNodeProvider = TestRPC.provider({ network_id: "5" });
+      webSocketServer = new WebSocket.Server({ port: "1337" });
+      webSocketServer.on('connection', (webSocket) => {
+        webSocket.on('message', (messageJson) => {
+          const message = JSON.parse(messageJson);
+          switch (message.method) {
+            case "eth_subscribe":
+              webSocket.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: "0xcd0c3e8af590364c09d0fa6a1210faf5" }));
+              break;
+            default:
+              ethereumNodeProvider.sendAsync(message, (error, result) => {
+                webSocket.send(JSON.stringify(result));
+              });
+              break;
+          }
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
This adds two tests, both backed by ethereumjs-testrpc.  One shows the websocket successfully reconnecting when the server goes away and comes back between calls.  The other shows the behavior (currently bad) when a request is attempted while the server is down.